### PR TITLE
Ensure every children of brick-deck is a brick-card

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,8 +15,7 @@ var paths = {
   'stylesheets': 'src/*.styl',
   'src': 'src/*',
   'index': 'index.html',
-  'bowerComponents': 'bower_components/**/*',
-  'testfiles': ['test/*', 'bower_components/platform/platform.js']
+  'bowerComponents': 'bower_components/**/*'
 };
 
 gulp.task('lint', function() {
@@ -53,7 +52,7 @@ gulp.task('server', ['build','connect','watch']);
 
 // run the tests
 gulp.task('test', function() {
-  return gulp.src(paths.testfiles)
+  return gulp.src('./notexists') // set up tests in karma.conf
     .pipe(karma({
       configFile: 'karma.conf.js',
       action: 'run'

--- a/src/deck.js
+++ b/src/deck.js
@@ -45,6 +45,16 @@
     }
   }
 
+
+  var card = document.createElement('brick-card');
+  //ensure the children is a brick-card (or wraps it with one)
+  function ensureIsCard(child){
+    if(child.tagName !== 'BRICK-CARD'){
+      var wrap = card.cloneNode();
+      child.parentNode.replaceChild(wrap, child);
+      wrap.appendChild(child);
+    }
+  }
   // check if a card is a card in a deck
   function checkCard(deck, card){
     return card &&
@@ -67,6 +77,22 @@
 
   BrickDeckElementPrototype.createdCallback = function() {
     this.ns = {};
+    var children = this.children, i, max;
+
+    for(i=0, max=children.length; i<max; i++){
+      ensureIsCard(children[i]);
+    }
+
+    var observer = new MutationObserver(function(mutations) {
+      mutations.forEach(function(mutation) {
+        var added = mutation.addedNodes || [];
+        for(var i=0, max=added.length; i<max; i++){
+          ensureIsCard(added[i]);
+        }
+      });
+    });
+
+    observer.observe(this, { childList: true });
   };
 
   BrickDeckElementPrototype.attachedCallback = function() {

--- a/test/browser.js
+++ b/test/browser.js
@@ -48,6 +48,7 @@ describe("brick-deck", function(){
     for (i = 0; i < cards.length; i++) {
       deck.appendChild(cards[i]);
     }
+
     document.body.appendChild(deck);
   });
 
@@ -211,6 +212,39 @@ describe("brick-deck", function(){
 
   });
 
+  describe("should allow any element as a child", function(){
+    it("automatically wraps non brick-card elements inside light dom", function(done){
+      var tmp = document.createElement('div');
+      tmp.innerHTML = '<brick-deck><section>1</section><div>2</div></brick-deck>';
+      document.body.appendChild(tmp);
+
+      var poll = function(){
+        if (tmp.firstChild.children[1].tagName === 'BRICK-CARD'){ // this will be DIV until after ready is finished.
+          expect(tmp.firstChild.children[1].tagName).to.be.equal('BRICK-CARD');
+          document.body.removeChild(tmp)
+          done();
+        } else {
+          setTimeout(poll, 100);
+        }
+      }
+      poll();
+    })
+
+    it("automatically wraps new non brick-card elements", function(done){
+      var deck = document.getElementById('deck');
+      var div = document.createElement('div');
+      deck.appendChild(div);
+
+      var poll = function(){
+        if(div.parentNode.tagName === 'BRICK-CARD'){
+          expect(div.parentNode.tagName).to.be.equal('BRICK-CARD');
+          done();
+        }else{
+          setTimeout(poll, 100);
+        }
+      }
+      poll();
+
+    })
+  })
 });
-
-


### PR DESCRIPTION
Enable brick-deck to use any element type, if it's not a brick-card it will automatically get wrapped by one 
In the test I had to use a polling strategy as in the MutationEvent the replacement is async, same for the create case, the element will not be available until after create.
Fixes #6

ps. this pr also fix a problem with gulp and karma, where gulp was overriding the karma configuration filenames, giving 404 errors in the html import, which made the test fail ad done was never called in the before all rule.
