### PR TITLE
Fix bug 11 cannot manually set selected

### DIFF
--- a/dist/brick-deck.js
+++ b/dist/brick-deck.js
@@ -138,7 +138,16 @@
   //ensure the children is a brick-card (or wraps it with one)
   function ensureIsCard(child){
     if(child.tagName !== 'BRICK-CARD'){
-      var wrap = card.cloneNode();
+      var wrap = card.cloneNode(),
+          attributes = ['selected', 'transition-type'],
+          attribute;
+
+      for(var i=0, max=attributes.length; i<max; i++){
+        attribute = attributes[i];
+        if(child.hasAttribute(attribute)){
+          wrap.setAttribute(attribute, child.getAttribute(attribute));
+        }
+      }
       child.parentNode.replaceChild(wrap, child);
       wrap.appendChild(child);
     }

--- a/src/deck.js
+++ b/src/deck.js
@@ -53,7 +53,16 @@
   //ensure the children is a brick-card (or wraps it with one)
   function ensureIsCard(child){
     if(child.tagName !== 'BRICK-CARD'){
-      var wrap = card.cloneNode();
+      var wrap = card.cloneNode(),
+          attributes = ['selected', 'transition-type'],
+          attribute;
+
+      for(var i=0, max=attributes.length; i<max; i++){
+        attribute = attributes[i];
+        if(child.hasAttribute(attribute)){
+          wrap.setAttribute(attribute, child.getAttribute(attribute));
+        }
+      }
       child.parentNode.replaceChild(wrap, child);
       wrap.appendChild(child);
     }

--- a/test/browser.js
+++ b/test/browser.js
@@ -277,5 +277,42 @@ describe("brick-deck", function(){
       poll();
 
     });
+
+    it("should copy over select attribute if present", function(done){
+      var deck = document.getElementById('deck');
+      var div = document.createElement('div');
+      div.setAttribute('selected', 'selected')
+      deck.appendChild(div);
+
+      var poll = function(){
+        if(div.parentNode.tagName === 'BRICK-CARD'){
+          expect(div.parentNode.tagName).to.be.equal('BRICK-CARD');
+          expect(div.parentNode.getAttribute('selected')).to.be.equal('selected');
+          done();
+        }else{
+          setTimeout(poll, 100);
+        }
+      };
+      poll();
+    });
+
+    it("should copy over transition-type attribute if present", function(done){
+      var deck = document.getElementById('deck');
+      var div = document.createElement('div');
+      div.setAttribute('transition-type', 'slide-down')
+      deck.appendChild(div);
+
+      var poll = function(){
+        if(div.parentNode.tagName === 'BRICK-CARD'){
+          expect(div.parentNode.tagName).to.be.equal('BRICK-CARD');
+          expect(div.parentNode.getAttribute('transition-type')).to.be.equal('slide-down');
+          done();
+        }else{
+          setTimeout(poll, 100);
+        }
+      };
+      poll();
+    });
   });
+
 });


### PR DESCRIPTION
Fixes #11 by copying the `selected` and `transition-type` attributes when wrapping non brick-card 
