### PR TITLE
use select-index to select the card on creation

### DIFF
--- a/dist/brick-deck.js
+++ b/dist/brick-deck.js
@@ -178,7 +178,7 @@
 
     for(i=0, max=children.length; i<max; i++){
       ensureIsCard(children[i]);
-      anyChildSelected = anyChildSelected || children[i].hasAttribute('selected')
+      anyChildSelected = anyChildSelected || children[i].hasAttribute('selected');
     }
 
     var observer = new MutationObserver(function(mutations) {

--- a/dist/brick-deck.js
+++ b/dist/brick-deck.js
@@ -174,10 +174,11 @@
 
   BrickDeckElementPrototype.createdCallback = function() {
     this.ns = {};
-    var children = this.children, i, max;
+    var children = this.children, i, max, anyChildSelected = false;
 
     for(i=0, max=children.length; i<max; i++){
       ensureIsCard(children[i]);
+      anyChildSelected = anyChildSelected || children[i].hasAttribute('selected')
     }
 
     var observer = new MutationObserver(function(mutations) {
@@ -190,6 +191,9 @@
     });
 
     observer.observe(this, { childList: true });
+    if(!anyChildSelected){
+      this.showCard(this.selectedIndex, {skipTransition:true});
+    }
   };
 
   BrickDeckElementPrototype.attachedCallback = function() {

--- a/src/deck.js
+++ b/src/deck.js
@@ -93,7 +93,7 @@
 
     for(i=0, max=children.length; i<max; i++){
       ensureIsCard(children[i]);
-      anyChildSelected = anyChildSelected || children[i].hasAttribute('selected')
+      anyChildSelected = anyChildSelected || children[i].hasAttribute('selected');
     }
 
     var observer = new MutationObserver(function(mutations) {

--- a/src/deck.js
+++ b/src/deck.js
@@ -89,10 +89,11 @@
 
   BrickDeckElementPrototype.createdCallback = function() {
     this.ns = {};
-    var children = this.children, i, max;
+    var children = this.children, i, max, anyChildSelected = false;
 
     for(i=0, max=children.length; i<max; i++){
       ensureIsCard(children[i]);
+      anyChildSelected = anyChildSelected || children[i].hasAttribute('selected')
     }
 
     var observer = new MutationObserver(function(mutations) {
@@ -105,6 +106,9 @@
     });
 
     observer.observe(this, { childList: true });
+    if(!anyChildSelected){
+      this.showCard(this.selectedIndex, {skipTransition:true});
+    }
   };
 
   BrickDeckElementPrototype.attachedCallback = function() {


### PR DESCRIPTION
if select-index is available on the deck on creation
and if no children has the selected attribute it will automatically
select the card.

Fixes #15
